### PR TITLE
FButton changes

### DIFF
--- a/BananaDemoProject/Assets/Plugins/Futile/Extras/FButton.cs
+++ b/BananaDemoProject/Assets/Plugins/Futile/Extras/FButton.cs
@@ -85,15 +85,6 @@ public class FButton : FContainer, FSingleTouchableInterface
 	{
 		get {return _label;}
 	}
-	
-	protected Vector2 MousePosition() {
-		float touchScale = 1.0f/Futile.displayScale;
-		
-		float offsetX = -Futile.screen.originX * Futile.screen.pixelWidth;
-		float offsetY = -Futile.screen.originY * Futile.screen.pixelHeight;
-		
-		return new Vector2((Input.mousePosition.x+offsetX)*touchScale, (Input.mousePosition.y+offsetY)*touchScale);	
-	}
 
 	override public void HandleAddedToStage()
 	{
@@ -116,7 +107,7 @@ public class FButton : FContainer, FSingleTouchableInterface
 	protected void UpdateHoverState() {
 		if (_hoverElement == null || !_shouldCheckForHoverState) return;
 		
-		Vector2 touchPos = _bg.GlobalToLocal(MousePosition());
+		Vector2 touchPos = _bg.GlobalToLocal(Futile.MousePosition());
 		
 		Rect expandedRect = _bg.textureRect.CloneWithExpansion(expansionAmount);
 		

--- a/BananaDemoProject/Assets/Plugins/Futile/Futile.cs
+++ b/BananaDemoProject/Assets/Plugins/Futile/Futile.cs
@@ -122,6 +122,15 @@ public class Futile : MonoBehaviour
 		AddStage (stage);
 	}
 	
+	static public Vector2 MousePosition() {
+		float touchScale = 1.0f/Futile.displayScale;
+		
+		float offsetX = -Futile.screen.originX * Futile.screen.pixelWidth;
+		float offsetY = -Futile.screen.originY * Futile.screen.pixelHeight;
+		
+		return new Vector2((Input.mousePosition.x+offsetX)*touchScale, (Input.mousePosition.y+offsetY)*touchScale);	
+	}
+	
 	static public void AddStage(FStage stageToAdd)
 	{
 		int stageIndex = _stages.IndexOf(stageToAdd);


### PR DESCRIPTION
Hey Matt,

I added a couple things.
1. I was frustrated that there wasn't a way to choose an image for when the mouse is hovering over an FButton so I added that. I'm aware that this needs to be deactivated for when you're not using a mouse, but wasn't sure how to do that.
2. For now, I added a static method to the Futile class so you can get the mouse position at any time

I'm fully aware that you'll probably want to implement all this in a better way yourself, but I'm sort of just trying out github and wanted to see if this worked. Obviously though, if you like the changes (specifically to FButton) feel free to merge 'em!

Thanks,
Whit
