### PR TITLE
RXRandom.Range fix for delta 0 bug

### DIFF
--- a/FutileProject/Assets/Futile/Rix/RXUtils.cs
+++ b/FutileProject/Assets/Futile/Rix/RXUtils.cs
@@ -341,7 +341,7 @@ public static class RXRandom
 	public static int Range(int low, int high)
 	{
 		int delta = high - low;
-		if(delta == 0) return 0;
+		if(delta == 0) return low;
 		return low + _randomSource.Next() % delta; 
 	}
 	


### PR DESCRIPTION
The range function will now return the low value when the delta between low and high are 0.

Signed-off-by: hyakugei jyule@phantomcompass.com
