### PR TITLE
some changes to FGameObjectNode

### DIFF
--- a/FutileProject/Assets/Futile/Display/FGameObjectNode.cs
+++ b/FutileProject/Assets/Futile/Display/FGameObjectNode.cs
@@ -137,7 +137,7 @@ public class FGameObjectNode : FNode, FRenderableLayerInterface
 		}
 	}
 	
-	virtual public void UpdateGameObject()
+	public void UpdateGameObject()
 	{
 		if(_isOnStage) {
 			FMatrix matrix = this.screenConcatenatedMatrix;


### PR DESCRIPTION
Hey Matt, I changed FGameObjectNode so that it stays true to the original GameObject's scale, and so that the rotation in the GameObject is all done around the global z axis based on the node's rotation. Lemme know what you think!
