### PR TITLE
FButton isEnabled fix.

### DIFF
--- a/FutileProject/Assets/Futile/Extras/FButton.cs
+++ b/FutileProject/Assets/Futile/Extras/FButton.cs
@@ -170,8 +170,6 @@ public class FButton : FContainer, FSingleTouchableInterface
 	
 	virtual public bool HandleSingleTouchBegan(FTouch touch)
 	{
-		if (!_isTouchDown) return; //If button is disabled, we still get the HandleSingleTouchMoved event but _isTouchDown is false, and we don't want to change the button state in that case
-
 		_isTouchDown = false;
 		
 		if(!IsAncestryVisible()) return false;
@@ -208,8 +206,8 @@ public class FButton : FContainer, FSingleTouchableInterface
 	
 	virtual public void HandleSingleTouchMoved(FTouch touch)
 	{
-		if (!_isTouchDown) return; //If button is disabled, or if mouse/touch went out of the expandedRect, we don't want to send the click Signal
-		
+		if (!_isTouchDown) return; //If button is disabled, we still get the HandleSingleTouchMoved event but _isTouchDown is false, and we don't want to change the button state in that case
+
         Vector2 touchPos = _sprite.GetLocalTouchPosition(touch);
 		
 		//expand the hitrect so that it has more error room around the edges
@@ -238,6 +236,8 @@ public class FButton : FContainer, FSingleTouchableInterface
 	
 	virtual public void HandleSingleTouchEnded(FTouch touch)
 	{
+		if (!_isTouchDown) return; //If button is disabled, or if mouse/touch went out of the expandedRect, we don't want to send the click Signal
+
 		_isTouchDown = false;
 		
 		_sprite.element = _upElement;


### PR DESCRIPTION
If _isEnabled if false, we still get the HandleSingleTouchMoved and the HandleSingleTouchEnded as HandleSingleTouchBegan rightfully returns true. I just added a check of _touchDown in HandleSingleTouchMoved and HandleSingleTouchEnded to fix this.
