### PR TITLE
MultiAtlas loading and Density Independent Atlas Loading

### DIFF
--- a/FutileProject/Assets/Futile/Core/FAtlasManager.cs
+++ b/FutileProject/Assets/Futile/Core/FAtlasManager.cs
@@ -115,27 +115,27 @@ public class FAtlasManager
 		}
 	}
 	
-	public void LoadAtlas(string atlasPath)
+	public void LoadAtlas(string atlasPath, bool densityIndependent = false)
 	{
 		if(DoesContainAtlas(atlasPath)) return; //we already have it, don't load it again
-		
-		string filePath = atlasPath+Futile.resourceSuffix+"_png";
-		
+
+		string filePath = atlasPath + (densityIndependent ? "" : Futile.resourceSuffix) + "_png";
+
 		TextAsset imageBytes = Resources.Load (filePath, typeof(TextAsset)) as TextAsset;
-		
+
 		if(imageBytes != null) //do we have png bytes?
 		{
 			Texture2D texture = new Texture2D(0,0,TextureFormat.ARGB32,false);
-			
+
 			texture.LoadImage(imageBytes.bytes);
-			
+
 			Resources.UnloadAsset(imageBytes);
-			
-			LoadAtlasFromTexture(atlasPath,atlasPath+Futile.resourceSuffix, texture);
+
+			LoadAtlasFromTexture(atlasPath,atlasPath + (densityIndependent ? "" : Futile.resourceSuffix), texture);
 		}
 		else //load it as a normal Unity image asset
 		{
-			ActuallyLoadAtlasOrImage(atlasPath, atlasPath+Futile.resourceSuffix, atlasPath+Futile.resourceSuffix);
+			ActuallyLoadAtlasOrImage(atlasPath, atlasPath + (densityIndependent ? "" : Futile.resourceSuffix), atlasPath + (densityIndependent ? "" : Futile.resourceSuffix));
 		}
 	}
 	


### PR DESCRIPTION
http://www.reddit.com/r/futile/comments/1vdwd0/loadatlases_instead_of_loadatlas/

posted the usage/why it's helpful on /r/futile

another edge case that we ran into was that some of our sprite sheets are density-independent (i.e. pixel art). Rather than making dupes of the file with different resource suffixes (which we would then have to keep in synch), we added an optional densityIndependent flag on LoadAtlas (debated whether this should be a new method or not).
